### PR TITLE
Fix opendf.exceptions.python_exception.SemanticException: Unexpected …

### DIFF
--- a/opendf/applications/smcalflow/nodes/time_nodes.py
+++ b/opendf/applications/smcalflow/nodes/time_nodes.py
@@ -568,11 +568,11 @@ class NumberWeekOfMonth(Node):
     def __init__(self):
         super().__init__(DateRange)
         self.signature.add_sig('month', [Str, Int], True)
-        self.signature.add_sig('num', Int, True)
+        self.signature.add_sig('number', Int, True)
 
     def exec(self, all_nodes=None, goals=None):
         month = self.get_dat("month")
-        num = self.get_dat("num")
+        num = self.get_dat("number")
         if isinstance(month, str):
             month = name_to_month(month)
         year = get_system_date().year


### PR DESCRIPTION
Dear authors,

The parameter name `num` of NumberWeekOfMonth should be `number` in order to match [here](https://github.com/hankcs/OpenDF/blob/afe7140e092627b2fdf48047112feabaea0dec05/opendf/applications/simplification/nodes/smcalflow_nodes.py#L2549) 