### PR TITLE
Make DowOfWeekNew accept DayOfWeek type

### DIFF
--- a/opendf/applications/smcalflow/nodes/time_nodes.py
+++ b/opendf/applications/smcalflow/nodes/time_nodes.py
@@ -695,7 +695,7 @@ class DowOfWeekNew(Node):
 
     def __init__(self):
         super().__init__(Date)
-        self.signature.add_sig(posname(1), Str, True, alias='dow')
+        self.signature.add_sig(posname(1), [Str, DayOfWeek], True, alias='dow')
         self.signature.add_sig(posname(2), DateRange, True, alias='week')
 
     def exec(self, all_nodes=None, goals=None):


### PR DESCRIPTION
Dear authors, 

I found some graphs in converted SMCalFlow that need the `DowOfWeekNew` node to accept `DayOfWeek`. E.g.,

```
do(
    Let(
       x0 ,
       DateTime?(
          date= DowOfWeekNew(
             dow= DayOfWeek(
                SATURDAY ) ,
             week= NextWeekList(
                ) ) ,
          time= NumberPM(
             6 ) ) ) ,
    CreateEvent(
       AND(
          at_location(
             Dive Bar ) ,
          has_subject(
             Mark's birthday party ) ,
          starts_at(
             $ x0 ) ,
          ends_at(
             AND(
                GE(
                   $ x0 ) ,
                NumberAM(
                   1 ) ) ) ,
          has_status(
             ShowAsStatus(
                Busy ) ) ) ) ) 
```