### PR TITLE
Fix Unexpected input name pos1 to node HourMilitary

### DIFF
--- a/opendf/applications/simplification/nodes/smcalflow_nodes.py
+++ b/opendf/applications/simplification/nodes/smcalflow_nodes.py
@@ -2041,6 +2041,7 @@ class HolidayYear(Node):
 class HourMilitary(Node):
     def __init__(self):
         super().__init__()
+        self.signature.add_sig('hours', Int, True)
         self.signature.add_sig('pos1', [Number, Int], alias='hours')
 
     def simplify(self, top, mode):

--- a/opendf/applications/smcalflow/nodes/time_nodes.py
+++ b/opendf/applications/smcalflow/nodes/time_nodes.py
@@ -1372,6 +1372,7 @@ class HourMilitary(Node):
 
     def __init__(self):
         super().__init__(Time)
+        self.signature.add_sig('pos1', Int, alias='hours')
         self.signature.add_sig('hours', Int, True)
 
     def exec(self, all_nodes=None, goals=None):


### PR DESCRIPTION
Dear authors, 

This patch is needed to run the following SMCalFlow program:

```
 FindEvents(
    AND(
       starts_at(
          Tomorrow(
             ) ) ,
       starts_at(
          GT(
             HourMilitary(
                14 ) ) ) ) ) 
```

The two `HourMinuteMilitary` implementations have to match their signatures. 