### PR TITLE
Fix signature of Date

### DIFF
--- a/opendf/applications/core/nodes/time_nodes.py
+++ b/opendf/applications/core/nodes/time_nodes.py
@@ -421,6 +421,7 @@ class Date(Node):
         self.signature.add_sig('month', Int, match_miss=True)
         self.signature.add_sig('day', Int, match_miss=True)
         self.signature.add_sig('dow', DayOfWeek, match_miss=True)
+        self.signature.add_sig('dayOfWeek', DayOfWeek, match_miss=True, alias='dow')
 
     def generate_sql_where(self, selection, parent_id, **kwargs):
         qualifier = kwargs.get("qualifier", EQ())


### PR DESCRIPTION
Dear authors, this patch fix `opendf.exceptions.python_exception.SemanticException: Unexpected input name dayOfWeek to node Date` raised in the following dialog.

## Dialog 102

**GUID**: `921adff2-0276-40a1-9cb3-1c7ed4ada011` **OpenDF**:

 - U1: I will be in Kirkland, but not on the weekend
 - A1: Does one of these work?
 - U2: Yes, the second one works perfect. Could you also put moving out on the calandar for me sometime **before the** weekend?
 - A2: I've put that on your calendar. __BREAK Does one of these work?
 - U3: Yes, either of those will work! Could you fit in a jump rope challenge but not this weekend. sooner.
 - A3: I've put that on your calendar on Monday the 27th from 10:00 to 10:30 AM. __BREAK Does one of these work?


```
 CreateEvent(
    AND(
       at_location(
          Kirkland ) ,
       avoid_start(
          Date?(
             dayOfWeek= Weekend(
                ) ) ) ) ) 
```